### PR TITLE
Use child_process.spawn instead of child_process.fork

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ void function () {
         args.push('--log-to-file');
         args.push(this.options.logToFile);
       }
-      child_process.fork(__dirname + '/../bin/mock-api-server', args);
+      child_process.spawn('' + __dirname + '/../bin/mock-api-server', args);
       return setTimeout(done, 500);
     };
     MockApi.prototype.stop = function () {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -12,7 +12,7 @@ class MockApi
       args.push '--log-to-file'
       args.push @options.logToFile
 
-    child_process.fork __dirname + '/../bin/mock-api-server', args
+    child_process.spawn "#{__dirname}/../bin/mock-api-server", args
     setTimeout done, 500
  
   stop: ->

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
For whatever reason, using `child_process.fork` causes the following code / command combo to loop indefinitely:

**test.coffee:**

```
console.log "hey!"
MockApi = require 'mock-api-server`
api = new MockApi(port: 7000)
api.start()
```

**shell:**

```
$ node -e 'require("coffee-script-redux/register");require("test");'
hey!
hey!
hey!
hey!
```

(Fake API connections refuse)

But this works fine:
**shell:**

```
$ ./node_modules/coffee-script-redux/bin/coffee test.coffee
hey!
```

(Fake API connections return data)

I'm not familiar enough with the difference between `fork` and `spawn` to figure out what's going on. For now, this should fix any fake-api issues we're seeing.
